### PR TITLE
Feature/split to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ As an example:
 $ ./bin/split.sh -c Authentication
 ```
 
+Two components have special rules: `Zend\Permissions\Acl` and
+`Zend\Permissinos\Rbac`; these are invoked as simply `Acl` and `Rbac`,
+respectively.
+
+The files will be split into a directory named after the component; e.g.,
+Authentication becomes `zend-authentication`, Acl becomes
+`zend-permissions-acl`, etc. This allows parallel runs in the same directory.
+
 ### Custom split
 
 The heavy-lifting utility is `bin/split-component.sh`. This script accepts the component

--- a/bin/normalize.php
+++ b/bin/normalize.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/functions.php';
+
+$stdin  = fopen('php://stdin', 'r');
+$stdout = fopen('php://stdout', 'wb+');
+
+while (! feof($stdin)) {
+    $string = fread($stdin, 4096);
+    if (false === $string) {
+        break;
+    }
+    fwrite($stdout, strtolower($string));
+}
+
+fclose($stdin);
+fclose($stdout);

--- a/bin/split.sh
+++ b/bin/split.sh
@@ -63,15 +63,31 @@ COMPONENT_PATH=${COMPONENT};
 if [[ "${COMPONENT}" = "Acl" ]];then
     COMPONENT="Permissions/Acl";
     COMPONENT_PATH="Permissions-Acl"
-fi
-if [[ "${COMPONENT}" = "Rbac" ]];then
-    COMPONENT="Permissions/Rbac";
-    COMPONENT_PATH="Permissions-Rbac"
+    ZF2_PATH="zend-permissions-acl"
+else
+    if [[ "${COMPONENT}" = "Rbac" ]];then
+        COMPONENT="Permissions/Rbac";
+        COMPONENT_PATH="Permissions-Rbac"
+        ZF2_PATH="zend-permissions-rbac"
+    else
+        COMPONENT_PATH=${COMPONENT}
+        ZF2_PATH="zend-$(echo ${COMPONENT} | $PHP_EXEC ${ROOT_DIR}/bin/normalize.php)"
+    fi
 fi
 
-PHPUNIT_DIST=${ROOT_DIR}/assets/root-files/${COMPONENT_PATH}/phpunit.xml.dist
-PHPUNIT_TRAVIS=${ROOT_DIR}/assets/root-files/${COMPONENT_PATH}/phpunit.xml.travis
-PHPCS=${ROOT_DIR}/assets/root-files/${COMPONENT_PATH}/php_cs
-README=${ROOT_DIR}/assets/root-files/${COMPONENT_PATH}/README.md
+ASSETS="${ROOT_DIR}/assets/root-files/${COMPONENT_PATH}"
 
-${ROOT_DIR}/bin/split-component.sh -c "${COMPONENT}" -p "${PHP_EXEC}" -u "${PHPUNIT_DIST}" -t "${PHPUNIT_TRAVIS}" -r "${README}" -s "${PHPCS}"
+PHPUNIT_DIST=${ASSETS}/phpunit.xml.dist
+PHPUNIT_TRAVIS=${ASSETS}/phpunit.xml.travis
+PHPCS=${ASSETS}/php_cs
+README=${ASSETS}/README.md
+
+echo "Splitting ${COMPONENT} using:"
+echo "    REPO PATH:             ${ZF2_PATH}"
+echo "    README:                ${README}"
+echo "    phpunit.xml.dist:      ${PHPUNIT_DIST}"
+echo "    phpunit.xml.travis:    ${PHPUNIT_TRAVIS}"
+echo "    php_cs:                ${PHPCS}"
+echo
+
+${ROOT_DIR}/bin/split-component.sh -c "${COMPONENT}" -z "${ZF2_PATH}" -p "${PHP_EXEC}" -u "${PHPUNIT_DIST}" -t "${PHPUNIT_TRAVIS}" -r "${README}" -s "${PHPCS}"


### PR DESCRIPTION
This is a proposed feature to simplify splitting components within the same checkout; by default, calling it with the component name will checkout ZF2 to a directory named after the component:
- Authentication becomes `zend-authentication`
- Acl becomes `zend-permissions-acl`
- etc.

I'm not merging this to master at this time, as it would impact doing parallel runs on _different_ machines.
